### PR TITLE
Correctly show comment time in results

### DIFF
--- a/views/default/search/comments/entity.php
+++ b/views/default/search/comments/entity.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Default search view for a comment
+ *
+ * @uses $vars['entity']
+ */
+
+$entity = $vars['entity'];
+
+$owner = get_entity($entity->getVolatileData('search_matched_comment_owner_guid'));
+
+if ($owner instanceof ElggUser) {
+    $icon = elgg_view_entity_icon($owner, 'tiny');
+} else {
+    $icon = '';
+}
+
+// @todo Sometimes we find comments on entities we can't display...
+if ($entity->getVolatileData('search_unavailable_entity')) {
+    $title = elgg_echo('search:comment_on', array(elgg_echo('search:unavailable_entity')));
+    // keep anchor for formatting.
+    $title = "<a>$title</a>";
+} else {
+    if ($entity->getType() == 'object') {
+        $title = $entity->title;
+    } else {
+        $title = $entity->name;
+    }
+
+    if (!$title) {
+        $title = elgg_echo('item:' . $entity->getType() . ':' . $entity->getSubtype());
+    }
+
+    if (!$title) {
+        $title = elgg_echo('item:' . $entity->getType());
+    }
+
+    $title = elgg_echo('search:comment_on', array($title));
+
+    // @todo this should use something like $comment->getURL()
+    $url = $entity->getURL() . '#comment_' . $entity->getVolatileData('search_match_annotation_id');
+    $title = "<a href=\"$url\">$title</a>";
+}
+
+$data = $entity->getVolatileData('search_comments_data');
+$data = $data[0];
+
+$time = elgg_view_friendly_time($data['time_created']);
+
+$body = "<p class=\"mbn\">$title</p>" . $data['text'];
+$body .= "<p class=\"elgg-subtext\">" . $time . "</p>";
+
+echo elgg_view_image_block($icon, $body);


### PR DESCRIPTION
This fixes a problem with the wrong time and content display of comments in search results. The problem occurs due to the modification of the volatile data in search_advanced compared to the search plugin.

![image](https://cloud.githubusercontent.com/assets/5213690/8409221/559856fe-1e76-11e5-8dd9-b4e188aa8d75.png)
